### PR TITLE
Docker configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,20 @@ COPY . /app
 # Build the Go app, making sure it is a static binary with no debugging symbols
 RUN cd cmd/dataapi && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -ldflags="-w -s"
 
+# Create non-root user information
+RUN echo "dataapi:x:65534:65534:Data API:/:" > /etc_passwd
+
 # Start over with a completely empty image
 FROM scratch
 
 # Copy over just the static binary to root
 COPY --from=compiler /app/cmd/dataapi/dataapi /dataapi
+
+# Copy over non-root user information
+COPY --from=0 /etc_passwd /etc/passwd
+
+# Run as non-root user in container
+USER dataapi
 
 # Expose port 8090 to the outside world
 EXPOSE 8090

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,10 @@ RUN go mod download
 COPY . /app
 
 # Build the Go app
-RUN cd cmd/dataapi && go build -o main .
+RUN cd cmd/dataapi && go build
 
 # Expose port 8090 to the outside world
 EXPOSE 8090
 
 # Command to run the executable
-CMD ["/app/cmd/dataapi/main"]
+CMD ["/app/cmd/dataapi/dataapi"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,11 @@ LABEL maintainer="G Katchoua <gkatchou@gmu.edu>"
 # Set the Current Working Directory inside the container
 WORKDIR /app
 
+# Copy dependencies prior to building so that this layer is cached unless
+# specified dependencies change
+COPY go.mod go.sum /app/
+RUN go mod download
+
 # Copy the source from the current directory to the Working Directory inside the container
 COPY . /app
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Set the following environment variables to configure the server:
 - `DATAAPI_DBUSER` (default: none)
 - `DATAAPI_DBPASS` (default: none)
 - `DATAAPI_SSL` (default: `require`; see [pq docs](https://godoc.org/github.com/lib/pq))
+- `DATAAPI_INTERFACE` (default: `0.0.0.0`)
 - `DATAAPI_PORT` (default: `8090`)
 - `DATAAPI_LOGGING` (default: `on`)
 

--- a/server.go
+++ b/server.go
@@ -48,7 +48,7 @@ func NewServer() *Server {
 	s.Config.dbpass = getEnv("DATAAPI_DBPASS", "")
 	s.Config.dbssl = getEnv("DATAAPI_SSL", "require")
 	s.Config.logging = getEnv("DATAAPI_LOGGING", "on") == "on"
-	s.Config.address = "localhost:" + getEnv("DATAAPI_PORT", "8090")
+	s.Config.address = getEnv("DATAAPI_INTERFACE", "0.0.0.0") + ":" + getEnv("DATAAPI_PORT", "8090")
 
 	// Connect to the database then store the database in the struct.
 	constr := fmt.Sprintf("host=%s port=%s dbname=%s user=%s password=%s sslmode=%s",


### PR DESCRIPTION
@katchoua I've made a few made a few proposed changes to the `Dockerfile`. The main difference is that this proposal uses a two-stage build (817f14d) to include only the static binary in the Docker image, which gets the image down from 800+ MB to about 7 MB. I've also made it run as a non-root user in the container.

Is this okay with you?